### PR TITLE
Updated MovementId in Glossary

### DIFF
--- a/source/documentation/glossary.html.md.erb
+++ b/source/documentation/glossary.html.md.erb
@@ -20,6 +20,6 @@ A glossary of some of the terms used in EMCS API.
 |     | Excise product code | Codes that are specific to the management, transport and taxation of products subject to Excise duties |
 | LRN | Local reference number | A unique serial number assigned to the eAD by the consignor which identifies the consignment in the records of the consignor |
 | MSA | Member state administration | The relevant administrative body for a member state |
-|     | Movement ID | UUID Reference for a cached movement in the EMCS API Database |
+|     | Movement ID | Reference for a cached movement in the EMCS API Database |
 |     | Trader ID | The excise reference number for a trader |
 |     | Trader type | The type of trader, for example GB registered warehousekeeper |

--- a/source/documentation/glossary.html.md.erb
+++ b/source/documentation/glossary.html.md.erb
@@ -20,6 +20,6 @@ A glossary of some of the terms used in EMCS API.
 |     | Excise product code | Codes that are specific to the management, transport and taxation of products subject to Excise duties |
 | LRN | Local reference number | A unique serial number assigned to the eAD by the consignor which identifies the consignment in the records of the consignor |
 | MSA | Member state administration | The relevant administrative body for a member state |
-|     | Movement ID | Unique reference for a movement when interacting with the API |
+|     | Movement ID | UUID Reference for a cached movement in the EMCS API Database |
 |     | Trader ID | The excise reference number for a trader |
 |     | Trader type | The type of trader, for example GB registered warehousekeeper |


### PR DESCRIPTION
Really quick change to the movementId in the glossary